### PR TITLE
2回目以降のSETボタン押下については枚数を変えられるようにしました。

### DIFF
--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -59,6 +59,25 @@ export default function Game(props) {
   const [preField, setPreField] = useState(field);
   const history = useHistory();
 
+  const [countClick, setCountClick] = useState(0);
+  function incrementCount() {
+    setCountClick(countClick + 1);
+    return countClick;
+  }
+
+  function changeCardByClick() {
+    const changeCards = getRandomCard(7);
+    if (countClick > 0) {
+      setField({
+        self: changeCards.slice(0, 3),
+        opp1: changeCards.slice(3, 5),
+        opp2: changeCards.slice(5, 7),
+        grave: field.grave,
+        selected: field.selected,
+      });
+    }
+  }
+
   function getRandomCard(count) {
     let result = [];
     let tmpDeck = deck.concat();
@@ -111,7 +130,7 @@ export default function Game(props) {
         <div className="btns_grave">
           <div className="btns">
             <Button
-              disabled={deck.length <= 11}
+              disabled={countClick >= 5}
               id="setButton"
               variant="contained"
               color="primary"
@@ -126,6 +145,8 @@ export default function Game(props) {
                   grave: field.grave,
                   selected: field.selected,
                 });
+                incrementCount();
+                changeCardByClick();
               }}
             >
               SET

--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -62,16 +62,24 @@ export default function Game(props) {
   const [countClick, setCountClick] = useState(0);
   function incrementCount() {
     setCountClick(countClick + 1);
-    return countClick;
   }
 
   function changeCardByClick() {
+    const changeCardsFirst = getRandomCard(15);
     const changeCards = getRandomCard(7);
     if (countClick > 0) {
       setField({
         self: changeCards.slice(0, 3),
         opp1: changeCards.slice(3, 5),
         opp2: changeCards.slice(5, 7),
+        grave: field.grave,
+        selected: field.selected,
+      });
+    } else if (countClick <= 0) {
+      setField({
+        self: changeCardsFirst.slice(0, 5),
+        opp1: changeCardsFirst.slice(5, 10),
+        opp2: changeCardsFirst.slice(10, 15),
         grave: field.grave,
         selected: field.selected,
       });
@@ -135,16 +143,8 @@ export default function Game(props) {
               variant="contained"
               color="primary"
               onClick={() => {
-                const randomCards = getRandomCard(15);
                 setPreDeck(deck);
                 setPreField(field);
-                setField({
-                  self: randomCards.slice(0, 5),
-                  opp1: randomCards.slice(5, 10),
-                  opp2: randomCards.slice(10, 15),
-                  grave: field.grave,
-                  selected: field.selected,
-                });
                 incrementCount();
                 changeCardByClick();
               }}

--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -145,8 +145,8 @@ export default function Game(props) {
               onClick={() => {
                 setPreDeck(deck);
                 setPreField(field);
-                incrementCount();
                 changeCardByClick();
+                incrementCount();
               }}
             >
               SET


### PR DESCRIPTION
お疲れ様です！

SETボタン2回目以降の押下時は、自分には3枚、相手には2枚排出されるようにする #52 
こちら完了しましたのでpushいたしました。

**clickCountとsetClickCountというstateを用意し、SETボタン押下時に数字が1ずつ増えるだけの関数を用意**
```
function incrementCount() {
    setCountClick(countClick + 1);
    return countClick;
  }
```

**countClickが0よりも大きくなった場合は自分には3枚、相手には2枚カードを渡す関数を用意しました**
```
  function changeCardByClick() {
    const changeCards = getRandomCard(7);
    if (countClick > 0) {
      setField({
        self: changeCards.slice(0, 3),
        opp1: changeCards.slice(3, 5),
        opp2: changeCards.slice(5, 7),
        grave: field.grave,
        selected: field.selected,
      });
    }
  }
```
そしてこれらをSETボタンのonClickに渡すことで実現しました。

また、SETボタンがdisabledになる瞬間に関しましても変更しまして、こちらdeck.lengthに応じてではなく、SETが5回押されることでSETボタンが非活性になるように変更しました。
（ジョーカーの有無、プレイヤー人数の変更により最終的なdeck.lengthがモードにより上下するため、SETの押下回数という形で統一しました）
`disabled={countClick >= 5}`
こちらは最終的なカードの枚数を計算するよりも公式ルールとして5ターンで1ゲームが終わるというところからこのようにした方が良いと判断しました

以上でございます！
ご確認よろしくお願いいたします！