### PR TITLE
2回目以降のSETボタン押下時にcardInformationの情報を検知して別のGameCardコンポーネントに配置したい。

### DIFF
--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -49,7 +49,6 @@ export default function Game(props) {
     grave: [],
     selected: [],
   });
-
   useEffect(() => {
     const tmpField = Object.assign({}, field);
     tmpField.selected = props.selectedCards;
@@ -58,6 +57,33 @@ export default function Game(props) {
 
   const [preField, setPreField] = useState(field);
   const history = useHistory();
+
+  const [countClick, setCountClick] = useState(0);
+  function incrementCount() {
+    setCountClick(countClick + 1);
+  }
+
+  function changeCardByClick() {
+    const changeCardsFirst = getRandomCard(15);
+    const changeCards = getRandomCard(7);
+    if (countClick > 0) {
+      setField({
+        self: changeCards.slice(0, 3),
+        opp1: changeCards.slice(3, 5),
+        opp2: changeCards.slice(5, 7),
+        grave: field.grave,
+        selected: field.selected,
+      });
+    } else if (countClick <= 0) {
+      setField({
+        self: changeCardsFirst.slice(0, 5),
+        opp1: changeCardsFirst.slice(5, 10),
+        opp2: changeCardsFirst.slice(10, 15),
+        grave: field.grave,
+        selected: field.selected,
+      });
+    }
+  }
 
   function getRandomCard(count) {
     let result = [];
@@ -90,12 +116,19 @@ export default function Game(props) {
     setDeck(returnDeck);
     return result;
   }
+  //[NOTE:OppField1でundifinedとなってしまっているため、
+  //この段階ではもうcardInformationの情報が取得できない]console.log(props.cardInformation);
 
   return (
     <div>
       <div className="boxes">
         <div className="boxes-1">
-          <OppField1 fieldKey="opp1" fieldCard={field} fieldSetter={setField} />
+          <OppField1
+            fieldKey="opp1"
+            fieldCard={field}
+            fieldSetter={setField}
+            data={props.cardInformation}
+          />
         </div>
         {props.memberCount === 3 && (
           <div className="boxes-2">
@@ -111,21 +144,15 @@ export default function Game(props) {
         <div className="btns_grave">
           <div className="btns">
             <Button
-              disabled={deck.length <= 11}
+              disabled={countClick >= 5}
               id="setButton"
               variant="contained"
               color="primary"
               onClick={() => {
-                const randomCards = getRandomCard(15);
                 setPreDeck(deck);
                 setPreField(field);
-                setField({
-                  self: randomCards.slice(0, 5),
-                  opp1: randomCards.slice(5, 10),
-                  opp2: randomCards.slice(10, 15),
-                  grave: field.grave,
-                  selected: field.selected,
-                });
+                changeCardByClick();
+                incrementCount();
               }}
             >
               SET

--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -42,13 +42,16 @@ export default function Game(props) {
   const [deck, setDeck] = useState(createCard());
   const [preDeck, setPreDeck] = useState(deck);
 
+  const defaultCardInformation = { type: undefined, number: undefined };
+
   const [field, setField] = useState({
-    self: [],
-    opp1: [],
-    opp2: [],
+    self: Array(13).fill(defaultCardInformation),
+    opp1: Array(13).fill(defaultCardInformation),
+    opp2: Array(13).fill(defaultCardInformation),
     grave: [],
     selected: [],
   });
+
   useEffect(() => {
     const tmpField = Object.assign({}, field);
     tmpField.selected = props.selectedCards;
@@ -64,25 +67,47 @@ export default function Game(props) {
   }
 
   function changeCardByClick() {
-    const changeCardsFirst = getRandomCard(15);
-    const changeCards = getRandomCard(7);
     if (countClick > 0) {
+      const changeCards = getRandomCard(7);
       setField({
-        self: changeCards.slice(0, 3),
-        opp1: changeCards.slice(3, 5),
-        opp2: changeCards.slice(5, 7),
+        self: concatFieldFromRandomCards(field.self, changeCards.slice(0, 3)),
+        opp1: concatFieldFromRandomCards(field.opp1, changeCards.slice(3, 5)),
+        opp2: concatFieldFromRandomCards(field.opp2, changeCards.slice(5, 7)),
         grave: field.grave,
         selected: field.selected,
       });
     } else if (countClick <= 0) {
+      const changeCardsFirst = getRandomCard(15);
       setField({
-        self: changeCardsFirst.slice(0, 5),
-        opp1: changeCardsFirst.slice(5, 10),
-        opp2: changeCardsFirst.slice(10, 15),
+        self: concatFieldFromRandomCards(
+          field.self,
+          changeCardsFirst.slice(0, 5)
+        ),
+        opp1: concatFieldFromRandomCards(
+          field.opp1,
+          changeCardsFirst.slice(5, 10)
+        ),
+        opp2: concatFieldFromRandomCards(
+          field.opp2,
+          changeCardsFirst.slice(10, 15)
+        ),
         grave: field.grave,
         selected: field.selected,
       });
     }
+  }
+
+  function concatFieldFromRandomCards(fieldCards, randomCards) {
+    const result = fieldCards.concat();
+    randomCards.forEach((randomCard) => {
+      const index = result.findIndex((fieldCard) => {
+        return fieldCard.type === undefined && fieldCard.number === undefined;
+      });
+      if (index !== -1) {
+        result[index] = randomCard;
+      }
+    });
+    return result;
   }
 
   function getRandomCard(count) {
@@ -97,6 +122,7 @@ export default function Game(props) {
         );
       });
     }
+    console.log(tmpDeck);
     setDeck(tmpDeck);
     return result;
   }

--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -142,8 +142,6 @@ export default function Game(props) {
     setDeck(returnDeck);
     return result;
   }
-  //[NOTE:OppField1でundifinedとなってしまっているため、
-  //この段階ではもうcardInformationの情報が取得できない]console.log(props.cardInformation);
 
   return (
     <div>

--- a/src/component/GameCard.jsx
+++ b/src/component/GameCard.jsx
@@ -40,8 +40,6 @@ export default function Card(props) {
     }
   }, [props.field, props.fieldKey, props.index]);
 
-  //[NOTE:この段階ではcardInformationの情報が取得できている]console.log(cardInformation);
-
   return (
     <DropTarget
       dropData={{

--- a/src/component/GameCard.jsx
+++ b/src/component/GameCard.jsx
@@ -26,7 +26,6 @@ export default function Card(props) {
       props.fieldSetter(tmpField);
     };
   }
-
   useEffect(() => {
     if (
       props.field &&
@@ -40,6 +39,9 @@ export default function Card(props) {
       callbackUpdatedField.current = null;
     }
   }, [props.field, props.fieldKey, props.index]);
+
+  //[NOTE:この段階ではcardInformationの情報が取得できている]console.log(cardInformation);
+
   return (
     <DropTarget
       dropData={{
@@ -69,6 +71,7 @@ export default function Card(props) {
               cardInformation.type,
               cardInformation.number
             )}
+            cardInformation={cardInformation}
             alt=""
           />
         </DragDropContainer>

--- a/src/component/OppField1.jsx
+++ b/src/component/OppField1.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import "../App.css";
 import GameCard from "./GameCard";
 export default function OppField1(props) {
+  //[NOTE:この段階ではもうcardInformationの情報が取得できない]console.log(props.cardInformation);
+
   return (
     <React.Fragment>
       <div className="box-row">

--- a/src/component/OppField1.jsx
+++ b/src/component/OppField1.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import "../App.css";
 import GameCard from "./GameCard";
 export default function OppField1(props) {
-  //[NOTE:この段階ではもうcardInformationの情報が取得できない]console.log(props.cardInformation);
-
   return (
     <React.Fragment>
       <div className="box-row">


### PR DESCRIPTION
お疲れ様です！

SETボタンを押下時に、2回目以降は空きのCardコンポーネントに排出されるようにする #51
こちらのissueにつきまして、止まってしまっているのでやり方お伺いしてもよろしいでしょうか？
—————————————————
やりたいこと：2回目以降のSETボタン押下時、GameCardコンポーネントのtypeもしくはnumberを検知して別のGameCardコンポーネントに排出されるようにしたい。

対応したこと：Game.jsxの中にあるOppFieldとSelfFieldの中のGameCardコンポーネントの中にcardInformationのtypeまたはnumberがあればchangeCardByClickはそこを避ける。という考え方の元、GameCardコンポーネントからcardInformationの情報をGame.jsx内で取得しようとしたがうまく行かない。

原因と思われること：孫コンポーネントから親コンポーネントへのstateの情報の渡し方をどこかで間違えている。もしくは下層コンポーネント内のstateであるcardInformationの情報を元にしなくても排出する方法があるかも。。
—————————————————
以上でございます！
まだコードとして記述できているところが少ないですが、孫コンポーネントからstateをもらいたい。といったときどのようにしたら良いかご教示いただけると・・！

恐れ入りますが、こちらご確認お願いいたします！