### PR TITLE
SETボタンで排出されたカードの情報を受け取り、RESETボタンの関数へと繋げたい

### DIFF
--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -45,7 +45,7 @@ export default function Game(props) {
   const defaultCardInformation = { type: undefined, number: undefined };
 
   const [field, setField] = useState({
-    self: Array(13).fill(defaultCardInformation),
+    self: Array(16).fill(defaultCardInformation),
     opp1: Array(13).fill(defaultCardInformation),
     opp2: Array(13).fill(defaultCardInformation),
     grave: [],

--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -64,8 +64,8 @@ export default function Game(props) {
   const [countClick, setCountClick] = useState(0);
   function incrementCount() {
     setCountClick(countClick + 1);
-    /*[TODO:現在クリック数にに応じて排出枚数を管理しているが、field内のカードの枚数に応じてカードの排出数を切り変えた方がいいかも]
-    Selectからカードを持って来て配置した際、SETボタンのクリック回数は問答無用で0となるため配りたい枚数とはならない可能性がある*/
+    /*[TODO:現在クリック数にに応じて排出枚数を管理しているが、field内のカードの枚数に応じてカードの排出数を切り変えた方がいいかも
+    Selectからカードを持って来て配置した際、SETボタンのクリック回数は問答無用で0となるため配りたい枚数とはならない可能性がある]*/
   }
 
   function changeCardByClick() {
@@ -101,8 +101,8 @@ export default function Game(props) {
 
   function resetCardByClick() {
     if (countClick > 1) {
-      const changeCards = resetRandomCard(7);
-      setPreField({
+      const changeCards = getRandomCard(7);
+      const resetedField = {
         self: concatFieldFromRandomCards(
           preField.self,
           changeCards.slice(0, 3)
@@ -117,29 +117,27 @@ export default function Game(props) {
         ),
         grave: preField.grave,
         selected: preField.selected,
-      });
-      setField(preField);
-      setDeck(preDeck);
+      };
+      setField(resetedField);
     } else if (countClick <= 1) {
-      const changeCardsFirst = resetRandomCard(15);
-      setPreField({
+      const changeCards = getRandomCard(15);
+      const resetedField = {
         self: concatFieldFromRandomCards(
           preField.self,
-          changeCardsFirst.slice(0, 5)
+          changeCards.slice(0, 5)
         ),
         opp1: concatFieldFromRandomCards(
           preField.opp1,
-          changeCardsFirst.slice(5, 10)
+          changeCards.slice(5, 10)
         ),
         opp2: concatFieldFromRandomCards(
           preField.opp2,
-          changeCardsFirst.slice(10, 15)
+          changeCards.slice(10, 15)
         ),
         grave: preField.grave,
         selected: preField.selected,
-      });
-      setField(preField);
-      setDeck(preDeck);
+      };
+      setField(resetedField);
     }
   }
 
@@ -172,7 +170,7 @@ export default function Game(props) {
     return result;
   }
 
-  function resetRandomCard(count) {
+  /*function resetRandomCard(count) {
     let result = [];
     let returnDeck = preDeck.concat();
     for (let i = 0; i < count; i++) {
@@ -186,7 +184,8 @@ export default function Game(props) {
     }
     setPreDeck(returnDeck);
     return result;
-  }
+  }*/
+
   return (
     <div>
       <div className="boxes">
@@ -245,7 +244,6 @@ export default function Game(props) {
                   onClick={() => {
                     setResetDialog(false);
                     resetCardByClick();
-                    console.log(preField);
                   }}
                 >
                   ランダム

--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -64,6 +64,8 @@ export default function Game(props) {
   const [countClick, setCountClick] = useState(0);
   function incrementCount() {
     setCountClick(countClick + 1);
+    /*[TODO:現在クリック数にに応じて排出枚数を管理しているが、field内のカードの枚数に応じてカードの排出数を切り変えた方がいいかも]
+    Selectからカードを持って来て配置した際、SETボタンのクリック回数は問答無用で0となるため配りたい枚数とはならない可能性がある*/
   }
 
   function changeCardByClick() {
@@ -97,6 +99,50 @@ export default function Game(props) {
     }
   }
 
+  function resetCardByClick() {
+    if (countClick > 1) {
+      const changeCards = resetRandomCard(7);
+      setPreField({
+        self: concatFieldFromRandomCards(
+          preField.self,
+          changeCards.slice(0, 3)
+        ),
+        opp1: concatFieldFromRandomCards(
+          preField.opp1,
+          changeCards.slice(3, 5)
+        ),
+        opp2: concatFieldFromRandomCards(
+          preField.opp2,
+          changeCards.slice(5, 7)
+        ),
+        grave: preField.grave,
+        selected: preField.selected,
+      });
+      setField(preField);
+      setDeck(preDeck);
+    } else if (countClick <= 1) {
+      const changeCardsFirst = resetRandomCard(15);
+      setPreField({
+        self: concatFieldFromRandomCards(
+          preField.self,
+          changeCardsFirst.slice(0, 5)
+        ),
+        opp1: concatFieldFromRandomCards(
+          preField.opp1,
+          changeCardsFirst.slice(5, 10)
+        ),
+        opp2: concatFieldFromRandomCards(
+          preField.opp2,
+          changeCardsFirst.slice(10, 15)
+        ),
+        grave: preField.grave,
+        selected: preField.selected,
+      });
+      setField(preField);
+      setDeck(preDeck);
+    }
+  }
+
   function concatFieldFromRandomCards(fieldCards, randomCards) {
     const result = fieldCards.concat();
     randomCards.forEach((randomCard) => {
@@ -122,7 +168,6 @@ export default function Game(props) {
         );
       });
     }
-    console.log(tmpDeck);
     setDeck(tmpDeck);
     return result;
   }
@@ -139,10 +184,9 @@ export default function Game(props) {
         );
       });
     }
-    setDeck(returnDeck);
+    setPreDeck(returnDeck);
     return result;
   }
-
   return (
     <div>
       <div className="boxes">
@@ -197,18 +241,11 @@ export default function Game(props) {
               </DialogContent>
               <DialogActions>
                 <Button
+                  disabled={countClick <= 0}
                   onClick={() => {
                     setResetDialog(false);
-                    setDeck(preDeck);
-                    setField(preField);
-                    const resetCards = resetRandomCard(15);
-                    setField({
-                      self: resetCards.slice(0, 5),
-                      opp1: resetCards.slice(5, 10),
-                      opp2: resetCards.slice(10, 15),
-                      grave: field.grave,
-                      selected: field.selected,
-                    });
+                    resetCardByClick();
+                    console.log(preField);
                   }}
                 >
                   ランダム

--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -101,7 +101,7 @@ export default function Game(props) {
 
   function resetCardByClick() {
     if (countClick > 1) {
-      const changeCards = getRandomCard(7);
+      const changeCards = resetRandomCard(7);
       const resetedField = {
         self: concatFieldFromRandomCards(
           preField.self,
@@ -120,7 +120,7 @@ export default function Game(props) {
       };
       setField(resetedField);
     } else if (countClick <= 1) {
-      const changeCards = getRandomCard(15);
+      const changeCards = resetRandomCard(15);
       const resetedField = {
         self: concatFieldFromRandomCards(
           preField.self,
@@ -142,6 +142,7 @@ export default function Game(props) {
   }
 
   function concatFieldFromRandomCards(fieldCards, randomCards) {
+    console.log(randomCards);
     const result = fieldCards.concat();
     randomCards.forEach((randomCard) => {
       const index = result.findIndex((fieldCard) => {
@@ -149,6 +150,11 @@ export default function Game(props) {
       });
       if (index !== -1) {
         result[index] = randomCard;
+      } else if (
+        randomCards.type !== undefined &&
+        randomCards.number !== undefined
+      ) {
+        setPreDeck(result);
       }
     });
     return result;
@@ -170,7 +176,7 @@ export default function Game(props) {
     return result;
   }
 
-  /*function resetRandomCard(count) {
+  function resetRandomCard(count) {
     let result = [];
     let returnDeck = preDeck.concat();
     for (let i = 0; i < count; i++) {
@@ -182,10 +188,11 @@ export default function Game(props) {
         );
       });
     }
-    setPreDeck(returnDeck);
+    setDeck(returnDeck);
     return result;
-  }*/
-
+  }
+  console.log(deck);
+  console.log(preDeck);
   return (
     <div>
       <div className="boxes">

--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -142,7 +142,6 @@ export default function Game(props) {
   }
 
   function concatFieldFromRandomCards(fieldCards, randomCards) {
-    console.log(randomCards);
     const result = fieldCards.concat();
     randomCards.forEach((randomCard) => {
       const index = result.findIndex((fieldCard) => {
@@ -150,16 +149,10 @@ export default function Game(props) {
       });
       if (index !== -1) {
         result[index] = randomCard;
-      } else if (
-        randomCards.type !== undefined &&
-        randomCards.number !== undefined
-      ) {
-        setPreDeck(result);
       }
     });
     return result;
   }
-
   function getRandomCard(count) {
     let result = [];
     let tmpDeck = deck.concat();
@@ -191,8 +184,7 @@ export default function Game(props) {
     setDeck(returnDeck);
     return result;
   }
-  console.log(deck);
-  console.log(preDeck);
+
   return (
     <div>
       <div className="boxes">


### PR DESCRIPTION
お疲れ様です！

RESETボタン押下時に、SETボタンで排出されたカードのみをリセットする #57
こちらのissueにつきまして、止まってしまっているのでやり方お伺いしてもよろしいでしょうか？
—————————————————
やりたいこと：RESETボタンのランダムボタンをクリックすると、1個前にSETボタンで排出されたカードのみをリセットしたい。

対応したこと：changeCardByClickと同じ要領でpreDeckとpreFieldを更新できるようなイメージでresetCardByClickという関数を作成したが、SETボタンを押した後にRESETを押すと、「カードを消す」という無駄な1ターンが入ってしまう。
RESETを押し続けても、SETボタンと同様の挙動となる。（これはおそらくconcatFieldFromRandomCardsを丸々使用しているのが原因と思ってます。。）

原因と思われること：setFieldとsetDeckが非同期的に処理されているため、無駄な1ターンが入っている。concatFieldFromRandomCardsを使用しての処理自体は必要なく、もしかしたらSETボタンで排出される検知してsetter関数を更新するだけで良いのかも・・。
—————————————————
以上でございます！

今回のissueを解決しようとした際、どのようにしてSETボタンで排出されたカードの情報を受け取り、RESETボタン用の関数にくっつけるかというところで若干混乱しており、、

恐れ入りますが、ご確認お願いいたします！